### PR TITLE
Feature/load static files on init

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,47 @@ Named after Carl Linnaeus, considered by some as the "father of modern taxonimy"
 embodies a ``condition classifier``; a logic engine capable of acting on trigger events, querying
 an external FHIR store for state and generating conditions when appropriate, pushed back into
 the same external FHIR store.
+
+## Conditions
+
+Start simple, in prototype style, with the intent to replace logic engine and related components
+as the need arises.
+
+### COPD & COPD Exacerbated
+
+Determine if a Patient should receive a COPD Condition with the `cnics` namespace system
+by looking for at least one `coding` from the following known COPD Condition codings:
+
+- "system": "http://hl7.org/fhir/sid/icd-9-cm"
+  - "code": "491"
+  - "code": "491.0"
+  - "code": "491.1"
+  - "code": "491.2"
+  - "code": "491.20"
+  - "code": "491.21"
+  - "code": "491.22"
+  - "code": "491.8"
+  - "code": "491.9"
+  - "code": "492"
+  - "code": "492.0"
+  - "code": "492.8"
+  - "code": "493.2"
+  - "code": "493.20"
+  - "code": "493.21"
+  - "code": "493.22"
+  - "code": "496"
+- "system": "http://hl7.org/fhir/sid/icd-10-cm"
+  - "code": "J41.0"
+  - "code": "J41.1"
+  - "code": "J41.8"
+  - "code": "J42"
+  - "code": "J43.0"
+  - "code": "J43.1"
+  - "code": "J43.2"
+  - "code": "J43.8"
+  - "code": "J43.9"
+  - "code": "J44.0"
+  - "code": "J44.1"
+  - "code": "J44.9"
+- "system": "http://snomed.info/sct"
+  - "code": "404684003"

--- a/carl/modules/codesystem.py
+++ b/carl/modules/codesystem.py
@@ -1,0 +1,21 @@
+"""FHIR CodeSystem module"""
+from carl.modules.resource import Resource
+
+
+class CodeSystem(Resource):
+    """FHIR CodeSystem - used for (de)serializing and queries"""
+    RESOURCE_TYPE = 'CodeSystem'
+
+    def __init__(self, url):
+        """Minimum necessary to uniquely define or query"""
+        super().__init__()
+        self._fields['url'] = url
+
+    @staticmethod
+    def unique_params():
+        return tuple(['url'])
+
+    @classmethod
+    def from_fhir(cls, data):
+        """Deserialize from json (FHIR) data"""
+        return cls(url=data['url'])

--- a/carl/modules/coding.py
+++ b/carl/modules/coding.py
@@ -1,0 +1,20 @@
+"""FHIR Coding module"""
+from carl.modules.resource import Resource
+
+
+class Coding(Resource):
+    """FHIR Coding - used for serializing and queries"""
+
+    def __init__(self, code, system):
+        super().__init__()
+        self._fields['code'] = code
+        self._fields['system'] = system
+
+    @staticmethod
+    def unique_params():
+        return tuple(['code', 'system'])
+
+    @classmethod
+    def from_fhir(cls, data):
+        """Deserialize from json (FHIR) data"""
+        return cls(code=data['code'], system=data['system'])

--- a/carl/modules/factories.py
+++ b/carl/modules/factories.py
@@ -1,0 +1,18 @@
+"""Factories to instantiate resources using runtime values"""
+from carl.modules.codesystem import CodeSystem
+from carl.modules.valueset import ValueSet
+
+
+def deserialize_resource(data):
+    """Given JSON data representation of FHIR Resource, return instance"""
+    # Cycle through known resource classes, looking for match to instantiate
+    resource = None
+    for cls in CodeSystem, ValueSet:
+        if cls.RESOURCE_TYPE == data['resourceType']:
+            assert resource is None
+            resource = cls.from_fhir(data)
+
+    if resource is None:
+        raise ValueError(f"FHIR resource f{data['resourceType']} class not found")
+
+    return resource

--- a/carl/modules/resource.py
+++ b/carl/modules/resource.py
@@ -1,0 +1,61 @@
+from collections import OrderedDict
+import requests
+from urllib.parse import urlencode
+
+from carl.config import FHIR_SERVER_URL
+
+
+class Resource(object):
+    """Abstract Base class for FHIR resources"""
+
+    def __init__(self):
+        self._fields = OrderedDict()
+        self._id = None
+
+    def __repr__(self):
+        if self._id is not None:
+            return f"<{self.RESOURCE_TYPE}/{self._id}>"
+        else:
+            return f"<{self.RESOURCE_TYPE}>"
+
+    def id(self):
+        """Look up FHIR id or return None if not found"""
+        if self._id is not None:
+            return self._id
+
+        # Round-trip to see if this represents a new or existing resource
+        if FHIR_SERVER_URL:
+            headers = {'Cache-Control': 'no-cache'}
+            response = requests.get('/'.join((FHIR_SERVER_URL, self.search_url())), headers=headers)
+            response.raise_for_status()
+
+            # extract Resource.id from bundle
+            bundle = response.json()
+            if bundle['total']:
+                if bundle['total'] > 1:
+                    raise RuntimeError(
+                        "Found multiple matches, can't generate upsert"
+                        f"for {self.search_url()}")
+                assert bundle['entry'][0]['resource']['resourceType'] == self.RESOURCE_TYPE
+                self._id = bundle['entry'][0]['resource']['id']
+        return self._id
+
+    def as_fhir(self):
+        results = {'resourceType': self.RESOURCE_TYPE}
+        results.update(self._fields)
+        return results
+
+    def search_url(self):
+        """Generate the request path search url for ValueSet
+
+        NB - this method does NOT invoke a round trip ID lookup.
+        Call self.id() beforehand to force a lookup.
+        """
+        if self._id:
+            return f"{self.RESOURCE_TYPE}/{self._id}"
+
+        search_params = {}
+        for key in self.unique_params():
+            if key in self._fields:
+                search_params[key] = self._fields[key]
+        return f"{self.RESOURCE_TYPE}?{urlencode(search_params)}"

--- a/carl/modules/valueset.py
+++ b/carl/modules/valueset.py
@@ -1,0 +1,21 @@
+"""FHIR ValueSet module"""
+from carl.modules.resource import Resource
+
+
+class ValueSet(Resource):
+    """FHIR ValueSet - used for (de)serializing and queries"""
+    RESOURCE_TYPE = 'ValueSet'
+
+    def __init__(self, url):
+        """Minimum necessary to uniquely define or query"""
+        super().__init__()
+        self._fields['url'] = url
+
+    @staticmethod
+    def unique_params():
+        return tuple(['url'])
+
+    @classmethod
+    def from_fhir(cls, data):
+        """Deserialize from json (FHIR) data"""
+        return cls(url=data['url'])

--- a/carl/serialized/COPD_valueset.json
+++ b/carl/serialized/COPD_valueset.json
@@ -1,0 +1,147 @@
+{
+  "resourceType": "ValueSet",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/StructureDefinition/shareablevalueset"
+    ]
+  },
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n\t\t\t<p>Value set &quot;CNICS Codes for COPD&quot;</p>\n\t\t\t<p>Developed by: CIRG</p>\n\t\t</div>"
+  },
+  "url": "http://cnics-cirg.washington.edu/fhir/ValueSet/CNICS-COPD-codings",
+  "identifier": [
+    {
+      "system": "http://cnics-cirg.washington.edu/fhir/identifier/valueset",
+      "value": "CNICS-COPD-codings"
+    }
+  ],
+  "version": "20211021",
+  "name": "CNICS COPD Codings",
+  "status": "draft",
+  "experimental": true,
+  "date": "2021-10-21",
+  "publisher": "CIRG",
+  "contact": [
+    {
+      "name": "CIRG project team",
+      "telecom": [
+        {
+          "system": "url",
+          "value": "https://www.cirg.washington.edu/"
+        }
+      ]
+    }
+  ],
+  "description": "ValueSet including all the codings used by CNICS to define COPD or COPD exacerbated",
+  "compose": {
+    "lockedDate": "2021-10-21",
+    "include": [
+      {
+        "system": "http://hl7.org/fhir/sid/icd-9-cm",
+        "concept": [
+          {
+            "code": "491"
+          },
+          {
+            "code": "491.0"
+          },
+          {
+            "code": "491.1"
+          },
+          {
+            "code": "491.2"
+          },
+          {
+            "code": "491.20"
+          },
+          {
+            "code": "491.21"
+          },
+          {
+            "code": "491.22"
+          },
+          {
+            "code": "491.8"
+          },
+          {
+            "code": "491.9"
+          },
+          {
+            "code": "492"
+          },
+          {
+            "code": "492.0"
+          },
+          {
+            "code": "492.8"
+          },
+          {
+            "code": "493.2"
+          },
+          {
+            "code": "493.20"
+          },
+          {
+            "code": "493.21"
+          },
+          {
+            "code": "493.22"
+          },
+          {
+            "code": "496"
+          }
+        ]
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "concept": [
+          {
+            "code": "J41.0"
+          },
+          {
+            "code": "J41.1"
+          },
+          {
+            "code": "J41.8"
+          },
+          {
+            "code": "J42"
+          },
+          {
+            "code": "J43.0"
+          },
+          {
+            "code": "J43.1"
+          },
+          {
+            "code": "J43.2"
+          },
+          {
+            "code": "J43.8"
+          },
+          {
+            "code": "J43.9"
+          },
+          {
+            "code": "J44.0"
+          },
+          {
+            "code": "J44.1"
+          },
+          {
+            "code": "J44.9"
+          }
+        ]
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "concept": [
+          {
+            "code": "404684003"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/carl/serialized/ICD10_codesystem.json
+++ b/carl/serialized/ICD10_codesystem.json
@@ -1,0 +1,4 @@
+{
+  "resourceType": "CodeSystem",
+  "url": "http://hl7.org/fhir/sid/icd-10-cm"
+}

--- a/carl/serialized/ICD9_codesystem.json
+++ b/carl/serialized/ICD9_codesystem.json
@@ -1,0 +1,4 @@
+{
+  "resourceType": "CodeSystem",
+  "url": "http://hl7.org/fhir/sid/icd-9-cm"
+}

--- a/carl/serialized/snomed_codesystem.json
+++ b/carl/serialized/snomed_codesystem.json
@@ -1,0 +1,4 @@
+{
+  "resourceType": "CodeSystem",
+  "url": "http://snomed.info/sct"
+}

--- a/carl/views.py
+++ b/carl/views.py
@@ -1,11 +1,43 @@
-import click
+import json
+import os
+
+import requests
 from flask import Blueprint, abort, current_app, jsonify
 from flask.json import JSONEncoder
-import sys
 
-from carl.audit import audit_entry
+from carl.modules.factories import deserialize_resource
 
 base_blueprint = Blueprint('base', __name__, cli_group=None)
+
+
+@base_blueprint.before_app_first_request
+def bootstrap():
+    """Run application initialization code"""
+    # Load serialized data into FHIR store
+    fhir_url = current_app.config['FHIR_SERVER_URL']
+    if not fhir_url:
+        current_app.logger.warn("No config set for FHIR_SERVER_URL, can't load serialized data")
+        return
+
+    base_dir = os.path.join(current_app.root_path, "serialized")
+    for fname in (fname for fname in os.scandir(base_dir) if fname.name.lower().endswith('.json')):
+        with open(fname.path) as fhir:
+            try:
+                data = json.loads(fhir.read())
+            except json.decoder.JSONDecodeError as je:
+                current_app.logger.error(f"{fname.path} contains invalid JSON")
+                current_app.logger.exception(je)
+
+            endpoint = fhir_url
+            if data['resourceType'] != 'Bundle':
+                # For non bundles, PUT with search parameters to avoid
+                # duplicate resource creation
+                resource = deserialize_resource(data)
+                endpoint += resource.search_url()
+
+            current_app.logger.info(f"PUT {fname.name} to {endpoint}")
+            response = requests.put(endpoint, json=data)
+            current_app.logger.info(f"status {response.status_code}, text {response.text}")
 
 
 @base_blueprint.route('/')
@@ -34,12 +66,12 @@ def config_settings(config_key):
                 abort(status_code=400, messag=f"Configuration key {key} not available")
         return jsonify({key: current_app.config.get(key)})
 
-    config_settings = {}
+    settings = {}
     for key in current_app.config:
         matches = any(pattern for pattern in blacklist if pattern in key)
         if matches:
             continue
-        config_settings[key] = current_app.config.get(key)
+        settings[key] = current_app.config.get(key)
 
-    return jsonify(config_settings)
+    return jsonify(settings)
 

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1,0 +1,35 @@
+import json
+import os
+from pytest import fixture
+
+from carl.modules.factories import deserialize_resource
+from carl.modules.codesystem import CodeSystem
+from carl.modules.valueset import ValueSet
+
+
+def load_jsondata(datadir, filename):
+    with open(os.path.join(datadir, filename), 'r') as jsonfile:
+        data = json.load(jsonfile)
+    return data
+
+
+@fixture
+def codesystem_data(datadir):
+    return load_jsondata(datadir, 'codesystem.json')
+
+
+@fixture
+def valueset_data(datadir):
+    return load_jsondata(datadir, 'valueset.json')
+
+
+def test_deserialize_codesystem(codesystem_data):
+    resource = deserialize_resource(codesystem_data)
+    assert isinstance(resource, CodeSystem)
+    assert resource.search_url() == 'CodeSystem?url=http%3A%2F%2Fhl7.org%2Ffhir%2Fsid%2Ficd-10-cm'
+
+
+def test_deserialize_valueset(valueset_data):
+    resource = deserialize_resource(valueset_data)
+    assert isinstance(resource, ValueSet)
+    assert resource.search_url() == 'ValueSet?url=http%3A%2F%2Fcnics-cirg.washington.edu%2Ffhir%2FValueSet%2FCNICS-COPD-codings'

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1,6 +1,7 @@
 import json
 import os
 from pytest import fixture
+from urllib.parse import urlencode
 
 from carl.modules.factories import deserialize_resource
 from carl.modules.codesystem import CodeSystem
@@ -26,10 +27,12 @@ def valueset_data(datadir):
 def test_deserialize_codesystem(codesystem_data):
     resource = deserialize_resource(codesystem_data)
     assert isinstance(resource, CodeSystem)
-    assert resource.search_url() == 'CodeSystem?url=http%3A%2F%2Fhl7.org%2Ffhir%2Fsid%2Ficd-10-cm'
+    encoded_url = urlencode(query={'url': "http://hl7.org/fhir/sid/icd-10-cm"})
+    assert resource.search_url() == f'CodeSystem?{encoded_url}'
 
 
 def test_deserialize_valueset(valueset_data):
     resource = deserialize_resource(valueset_data)
     assert isinstance(resource, ValueSet)
-    assert resource.search_url() == 'ValueSet?url=http%3A%2F%2Fcnics-cirg.washington.edu%2Ffhir%2FValueSet%2FCNICS-COPD-codings'
+    encoded_url = urlencode(query={'url': "http://cnics-cirg.washington.edu/fhir/ValueSet/CNICS-COPD-codings"})
+    assert resource.search_url() == f'ValueSet?{encoded_url}'

--- a/tests/test_modules/codesystem.json
+++ b/tests/test_modules/codesystem.json
@@ -1,0 +1,4 @@
+{
+  "resourceType": "CodeSystem",
+  "url": "http://hl7.org/fhir/sid/icd-10-cm"
+}

--- a/tests/test_modules/valueset.json
+++ b/tests/test_modules/valueset.json
@@ -1,0 +1,147 @@
+{
+  "resourceType": "ValueSet",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/StructureDefinition/shareablevalueset"
+    ]
+  },
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n\t\t\t<p>Value set &quot;CNICS Codes for COPD&quot;</p>\n\t\t\t<p>Developed by: CIRG</p>\n\t\t</div>"
+  },
+  "url": "http://cnics-cirg.washington.edu/fhir/ValueSet/CNICS-COPD-codings",
+  "identifier": [
+    {
+      "system": "http://cnics-cirg.washington.edu/fhir/identifier/valueset",
+      "value": "CNICS-COPD-codings"
+    }
+  ],
+  "version": "20211021",
+  "name": "CNICS COPD Codings",
+  "status": "draft",
+  "experimental": true,
+  "date": "2021-10-21",
+  "publisher": "CIRG",
+  "contact": [
+    {
+      "name": "CIRG project team",
+      "telecom": [
+        {
+          "system": "url",
+          "value": "https://www.cirg.washington.edu/"
+        }
+      ]
+    }
+  ],
+  "description": "ValueSet including all the codings used by CNICS to define COPD or COPD exacerbated",
+  "compose": {
+    "lockedDate": "2021-10-21",
+    "include": [
+      {
+        "system": "http://hl7.org/fhir/sid/icd-9-cm",
+        "concept": [
+          {
+            "code": "491"
+          },
+          {
+            "code": "491.0"
+          },
+          {
+            "code": "491.1"
+          },
+          {
+            "code": "491.2"
+          },
+          {
+            "code": "491.20"
+          },
+          {
+            "code": "491.21"
+          },
+          {
+            "code": "491.22"
+          },
+          {
+            "code": "491.8"
+          },
+          {
+            "code": "491.9"
+          },
+          {
+            "code": "492"
+          },
+          {
+            "code": "492.0"
+          },
+          {
+            "code": "492.8"
+          },
+          {
+            "code": "493.2"
+          },
+          {
+            "code": "493.20"
+          },
+          {
+            "code": "493.21"
+          },
+          {
+            "code": "493.22"
+          },
+          {
+            "code": "496"
+          }
+        ]
+      },
+      {
+        "system": "http://hl7.org/fhir/sid/icd-10-cm",
+        "concept": [
+          {
+            "code": "J41.0"
+          },
+          {
+            "code": "J41.1"
+          },
+          {
+            "code": "J41.8"
+          },
+          {
+            "code": "J42"
+          },
+          {
+            "code": "J43.0"
+          },
+          {
+            "code": "J43.1"
+          },
+          {
+            "code": "J43.2"
+          },
+          {
+            "code": "J43.8"
+          },
+          {
+            "code": "J43.9"
+          },
+          {
+            "code": "J44.0"
+          },
+          {
+            "code": "J44.1"
+          },
+          {
+            "code": "J44.9"
+          }
+        ]
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "concept": [
+          {
+            "code": "404684003"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
On first page request, view `bootstrap()` seeks out all serialized json config files and PUTs to HAPI.

Minimal FHIR resource classes can deserialize JSON to leverage HAPI's [Conditional Update](https://www.hl7.org/fhir/http.html#cond-update) to prevent round trips or generate duplicate resources on subsequent restarts.

Initial set of added resources are needed to query for any `coding` in the COPD `ValueSet`