### PR TITLE
Load static data into HAPI from CLI

### DIFF
--- a/carl/modules/valueset.py
+++ b/carl/modules/valueset.py
@@ -32,7 +32,9 @@ def valueset_codings(url):
     response = requests.get(resource_path, params=search_params)
     response.raise_for_status()
     bundle = response.json()
-    assert bundle['total'] == 1
+    if bundle['total'] != 1:
+        raise ValueError(
+            "Expected ValueSet {url} not found; Did `flask bootstrap` get called?")
 
     value_set = bundle['entry'][0]['resource']
     codings = set()

--- a/carl/views.py
+++ b/carl/views.py
@@ -9,7 +9,7 @@ from carl.modules.paging import next_resource_bundle
 base_blueprint = Blueprint('base', __name__, cli_group=None)
 
 
-@base_blueprint.before_app_first_request
+@base_blueprint.cli.command("bootstrap")
 def bootstrap():
     """Run application initialization code"""
     # Load serialized data into FHIR store


### PR DESCRIPTION
Previously, the first flask request would trigger loading static data into HAPI.

That worked fine until an attempt to use a CLI endpoint after cleansing the HAPI volume before any HTTP requests came in exposed an alternate path.

On deploy, we should now invoke `flask bootstrap` and a reasonable exception has been added to explain the potential oversight.