### PR TITLE
Match updated identifier system and classify by site

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ sudo docker-compose exec carl flask --help
 Especially useful for debugging or testing, obtain any single Patient `_id` from the configured
 FHIR store, and process via:
 ```
-curl -X PUT http://localhost:5000/classify/<Patient._id>
+curl -X PUT http://localhost:5000/classify/<Patient._id>/<site>
 ```
 
 To process the entire set of Patient resources found in the configured FHIR store:
@@ -74,8 +74,8 @@ To process the entire set of Patient resources found in the configured FHIR stor
 sudo docker-compose run carl flask classify
 ```
 
-Complete example, captures both standard out and error to respective log files:
+Complete example for site `uw`, captures both standard out and error to respective log files:
 ```
-sudo docker-compose run carl flask classify > /var/log/cnics_to_fhir/carl.out 2> /var/log/cnics_to_fhir/carl.err
+sudo docker-compose run carl flask classify uw > /var/log/cnics_to_fhir/carl.out 2> /var/log/cnics_to_fhir/carl.err
 ```
 

--- a/carl/views.py
+++ b/carl/views.py
@@ -3,7 +3,7 @@ from flask import Blueprint, abort, current_app, jsonify
 from flask.json import JSONEncoder
 import timeit
 
-from carl.logic.copd import process_4_COPD
+from carl.logic.copd import CNICS_IDENTIFIER_SYSTEM, process_4_COPD
 from carl.modules.paging import next_resource_bundle
 
 base_blueprint = Blueprint('base', __name__, cli_group=None)
@@ -53,25 +53,27 @@ def config_settings(config_key):
     return jsonify(settings)
 
 
-@base_blueprint.route('/classify/<int:patient_id>', methods=['PUT'])
-def classify(patient_id):
+@base_blueprint.route('/classify/<int:patient_id>/<string:site_code>', methods=['PUT'])
+def classify(patient_id, site_code):
     """Classify single patient as configured"""
-    return process_4_COPD(patient_id)
+    return process_4_COPD(patient_id, site_code)
 
 
 @base_blueprint.cli.command("classify")
-def classify_all():
+@click.argument('site')
+def classify_all(site):
     """Classify all patients found"""
     start = timeit.default_timer()
 
-    # Obtain batches of Patients, process each in turn
+    # Obtain batches of Patients with matching site identifier, process each in turn
     processed_patients = 0
     conditioned_patients = 0
-    for bundle in next_resource_bundle('Patient'):
+    patient_identifier_system = CNICS_IDENTIFIER_SYSTEM + site
+    for bundle in next_resource_bundle('Patient', search_params={'identifier': patient_identifier_system}):
         assert bundle['resourceType'] == 'Bundle'
         for item in bundle.get('entry', []):
             assert item['resource']['resourceType'] == 'Patient'
-            results = process_4_COPD(item['resource']['id'])
+            results = process_4_COPD(item['resource']['id'], site)
             processed_patients += 1
             if 'condition' in results:
                 conditioned_patients += 1
@@ -79,5 +81,6 @@ def classify_all():
     duration = timeit.default_timer() - start
     click.echo({
         'duration': f"{duration:.4f} seconds",
+        'patient_identifier_system': patient_identifier_system,
         'processed_patients': processed_patients,
         'conditioned_patients': conditioned_patients})

--- a/carl/views.py
+++ b/carl/views.py
@@ -69,7 +69,10 @@ def classify_all(site):
     processed_patients = 0
     conditioned_patients = 0
     patient_identifier_system = CNICS_IDENTIFIER_SYSTEM + site
-    for bundle in next_resource_bundle('Patient', search_params={'identifier': patient_identifier_system}):
+    # To query on system portion only of an identifier, must include
+    # trailing '|' used customarily to delimit `system|value`
+    search_params = {'identifier': patient_identifier_system + '|'}
+    for bundle in next_resource_bundle('Patient', search_params=search_params):
         assert bundle['resourceType'] == 'Bundle'
         for item in bundle.get('entry', []):
             assert item['resource']['resourceType'] == 'Patient'

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -141,5 +141,5 @@ def test_canonical_identifier(mocker, patient_data):
         'carl.logic.copd.requests.get',
         return_value=MockResponse(data=patient_data))
 
-    found = patient_canonical_identifier(patient_id=1)
-    assert found == "https://cnics.cirg.washington.edu/|UW:517"
+    found = patient_canonical_identifier(patient_id=1, site_code="uw")
+    assert found == "https://cnics.cirg.washington.edu/site-patient-id/uw|UW:517"

--- a/tests/test_modules/patient.json
+++ b/tests/test_modules/patient.json
@@ -29,7 +29,7 @@
     "valueCode": "M"
   } ],
   "identifier": [ {
-    "system": "https://cnics.cirg.washington.edu/",
+    "system": "https://cnics.cirg.washington.edu/site-patient-id/uw",
     "value": "UW:517"
   } ],
   "gender": "male"

--- a/tests/test_modules/patient_search.json
+++ b/tests/test_modules/patient_search.json
@@ -58,7 +58,7 @@
         "valueCode": "M"
       } ],
       "identifier": [ {
-        "system": "https://cnics.cirg.washington.edu/",
+        "system": "https://cnics.cirg.washington.edu/site-patient-id/uw",
         "value": "UW:8585"
       } ],
       "gender": "male"
@@ -112,7 +112,7 @@
         "valueCode": "M"
       } ],
       "identifier": [ {
-        "system": "https://cnics.cirg.washington.edu/",
+        "system": "https://cnics.cirg.washington.edu/site-patient-id/uw",
         "value": "UW:2335"
       } ],
       "gender": "male"
@@ -166,7 +166,7 @@
         "valueCode": "F"
       } ],
       "identifier": [ {
-        "system": "https://cnics.cirg.washington.edu/",
+        "system": "https://cnics.cirg.washington.edu/site-patient-id/uw",
         "value": "UW:3504"
       } ],
       "gender": "female"
@@ -220,7 +220,7 @@
         "valueCode": "M"
       } ],
       "identifier": [ {
-        "system": "https://cnics.cirg.washington.edu/",
+        "system": "https://cnics.cirg.washington.edu/site-patient-id/uw",
         "value": "UW:6731"
       } ],
       "gender": "male"
@@ -261,7 +261,7 @@
         "valueCode": "M"
       } ],
       "identifier": [ {
-        "system": "https://cnics.cirg.washington.edu/",
+        "system": "https://cnics.cirg.washington.edu/site-patient-id/uw",
         "value": "UW:1971"
       } ],
       "gender": "male"
@@ -315,7 +315,7 @@
         "valueCode": "M"
       } ],
       "identifier": [ {
-        "system": "https://cnics.cirg.washington.edu/",
+        "system": "https://cnics.cirg.washington.edu/site-patient-id/uw",
         "value": "UW:10792"
       } ],
       "gender": "male"
@@ -369,7 +369,7 @@
         "valueCode": "M"
       } ],
       "identifier": [ {
-        "system": "https://cnics.cirg.washington.edu/",
+        "system": "https://cnics.cirg.washington.edu/site-patient-id/uw",
         "value": "UW:9398"
       } ],
       "gender": "male"
@@ -423,7 +423,7 @@
         "valueCode": "M"
       } ],
       "identifier": [ {
-        "system": "https://cnics.cirg.washington.edu/",
+        "system": "https://cnics.cirg.washington.edu/site-patient-id/uw",
         "value": "UW:4537"
       } ],
       "gender": "male"
@@ -477,7 +477,7 @@
         "valueCode": "M"
       } ],
       "identifier": [ {
-        "system": "https://cnics.cirg.washington.edu/",
+        "system": "https://cnics.cirg.washington.edu/site-patient-id/uw",
         "value": "UW:6374"
       } ],
       "gender": "male"
@@ -518,7 +518,7 @@
         "valueCode": "M"
       } ],
       "identifier": [ {
-        "system": "https://cnics.cirg.washington.edu/",
+        "system": "https://cnics.cirg.washington.edu/site-patient-id/uw",
         "value": "UW:1104"
       } ],
       "gender": "male"
@@ -572,7 +572,7 @@
         "valueCode": "M"
       } ],
       "identifier": [ {
-        "system": "https://cnics.cirg.washington.edu/",
+        "system": "https://cnics.cirg.washington.edu/site-patient-id/uw",
         "value": "UW:4889"
       } ],
       "gender": "male"
@@ -613,7 +613,7 @@
         "valueCode": "M"
       } ],
       "identifier": [ {
-        "system": "https://cnics.cirg.washington.edu/",
+        "system": "https://cnics.cirg.washington.edu/site-patient-id/uw",
         "value": "UW:8911"
       } ],
       "gender": "male"
@@ -654,7 +654,7 @@
         "valueCode": "F"
       } ],
       "identifier": [ {
-        "system": "https://cnics.cirg.washington.edu/",
+        "system": "https://cnics.cirg.washington.edu/site-patient-id/uw",
         "value": "UW:1934"
       } ],
       "gender": "female"
@@ -708,7 +708,7 @@
         "valueCode": "M"
       } ],
       "identifier": [ {
-        "system": "https://cnics.cirg.washington.edu/",
+        "system": "https://cnics.cirg.washington.edu/site-patient-id/uw",
         "value": "UW:3920"
       } ],
       "gender": "male"
@@ -762,7 +762,7 @@
         "valueCode": "M"
       } ],
       "identifier": [ {
-        "system": "https://cnics.cirg.washington.edu/",
+        "system": "https://cnics.cirg.washington.edu/site-patient-id/uw",
         "value": "UW:10225"
       } ],
       "gender": "male"
@@ -816,7 +816,7 @@
         "valueCode": "M"
       } ],
       "identifier": [ {
-        "system": "https://cnics.cirg.washington.edu/",
+        "system": "https://cnics.cirg.washington.edu/site-patient-id/uw",
         "value": "UW:7745"
       } ],
       "gender": "male"
@@ -870,7 +870,7 @@
         "valueCode": "M"
       } ],
       "identifier": [ {
-        "system": "https://cnics.cirg.washington.edu/",
+        "system": "https://cnics.cirg.washington.edu/site-patient-id/uw",
         "value": "UW:6296"
       } ],
       "gender": "male"
@@ -924,7 +924,7 @@
         "valueCode": "M"
       } ],
       "identifier": [ {
-        "system": "https://cnics.cirg.washington.edu/",
+        "system": "https://cnics.cirg.washington.edu/site-patient-id/uw",
         "value": "UW:8464"
       } ],
       "gender": "male"
@@ -978,7 +978,7 @@
         "valueCode": "M"
       } ],
       "identifier": [ {
-        "system": "https://cnics.cirg.washington.edu/",
+        "system": "https://cnics.cirg.washington.edu/site-patient-id/uw",
         "value": "UW:4885"
       } ],
       "gender": "male"
@@ -1032,7 +1032,7 @@
         "valueCode": "M"
       } ],
       "identifier": [ {
-        "system": "https://cnics.cirg.washington.edu/",
+        "system": "https://cnics.cirg.washington.edu/site-patient-id/uw",
         "value": "UW:6989"
       } ],
       "gender": "male"


### PR DESCRIPTION
- extend views and CLI endpoints to classify by site, i.e. `uw`.
- updated to match identification system generated by the `cnics-to-fhir` process.

NB: must now include the site code when calling classify:
```
sudo docker-compose run carl flask classify uw > /var/log/cnics_to_fhir/carl.out 2> /var/log/cnics_to_fhir/carl.err
```