### PR TITLE
remove SNOMED code: 404684003 ; declassify

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@ by looking for at least one `coding` from the following known COPD Condition cod
   - "code": "J44.0"
   - "code": "J44.1"
   - "code": "J44.9"
-- "system": "http://snomed.info/sct"
-  - "code": "404684003"
 
 ## How To Run
 As a flask application, `carl` exposes HTTP routes as well as a number of command line
@@ -55,12 +53,12 @@ portion of each command if deployed outside a docker container.
 
 To view available HTTP routes:
 ```
-sudo docker-compose exec carl flask routes
+docker-compose exec carl flask routes
 ```
 
 To view available CLI entry points:
 ```
-sudo docker-compose exec carl flask --help
+docker-compose exec carl flask --help
 ```
 
 Especially useful for debugging or testing, obtain any single Patient `_id` from the configured
@@ -71,11 +69,15 @@ curl -X PUT http://localhost:5000/classify/<Patient._id>/<site>
 
 To process the entire set of Patient resources found in the configured FHIR store:
 ```
-sudo docker-compose run carl flask classify
+docker-compose run carl flask classify
+```
+
+To reset, that is remove conditions added from previous runs:
+```
+docker-compose run carl flask declassify
 ```
 
 Complete example for site `uw`, captures both standard out and error to respective log files:
 ```
-sudo docker-compose run carl flask classify uw > /var/log/cnics_to_fhir/carl.out 2> /var/log/cnics_to_fhir/carl.err
+docker-compose run carl flask classify uw > /var/log/cnics_to_fhir/carl.out 2> /var/log/cnics_to_fhir/carl.err
 ```
-

--- a/carl/logic/copd.py
+++ b/carl/logic/copd.py
@@ -123,8 +123,7 @@ def remove_COPD_classification(patient_id, site_code):
     configured FHIR store for patients found to have previously gained said Condition
     """
     current_app.logger.debug(f"declassify {patient_id} of COPD")
-    classified_COPD_coding = set(
-        [Coding(system=CNICS_COPD_coding.system, code=CNICS_COPD_coding.code)])
+    classified_COPD_coding = set([CNICS_COPD_coding])
     previously_classified = patient_has(
         patient_id=patient_id, condition_codings=classified_COPD_coding)
     results = {

--- a/carl/logic/copd.py
+++ b/carl/logic/copd.py
@@ -124,7 +124,7 @@ def remove_COPD_classification(patient_id, site_code):
     """
     current_app.logger.debug(f"declassify {patient_id} of COPD")
     classified_COPD_coding = set(
-        [Coding(system=CNICS_COPD_coding['system'], code=CNICS_COPD_coding['code'])])
+        [Coding(system=CNICS_COPD_coding.system, code=CNICS_COPD_coding.code)])
     previously_classified = patient_has(
         patient_id=patient_id, condition_codings=classified_COPD_coding)
     results = {

--- a/carl/logic/copd.py
+++ b/carl/logic/copd.py
@@ -104,7 +104,7 @@ def process_4_COPD(patient_id, site_code):
     condition.code = CodeableConcept(CNICS_COPD_coding)
     condition.subject = Patient(patient_id)
     response = persist_resource(resource=condition)
-    results['changed'] = True
+    results['matched'] = True
     results['condition'] = response
     results['intersection'] = [coding.as_fhir() for coding in positive_codings]
 
@@ -136,7 +136,7 @@ def remove_COPD_classification(patient_id, site_code):
     condition.code = CodeableConcept(CNICS_COPD_coding)
     condition.subject = Patient(patient_id)
     delete_resource(resource=condition)
-    results['changed'] = True
+    results['matched'] = True
 
     current_app.logger.debug(results)
     return results

--- a/carl/serialized/COPD_valueset.json
+++ b/carl/serialized/COPD_valueset.json
@@ -162,15 +162,6 @@
             "display": "J44.9"
           }
         ]
-      },
-      {
-        "system": "http://snomed.info/sct",
-        "concept": [
-          {
-            "code": "404684003",
-            "display": "404684003"
-          }
-        ]
       }
     ]
   }

--- a/carl/views.py
+++ b/carl/views.py
@@ -89,7 +89,7 @@ def process_patients(process_function, site):
             assert item['resource']['resourceType'] == 'Patient'
             results = process_function(patient_id=item['resource']['id'], site_code=site)
             processed_patients += 1
-            if results.get('match', False):
+            if results.get('matched', False):
                 matched_patients += 1
 
     duration = timeit.default_timer() - start

--- a/tests/test_modules/valueset.json
+++ b/tests/test_modules/valueset.json
@@ -133,14 +133,6 @@
             "code": "J44.9"
           }
         ]
-      },
-      {
-        "system": "http://snomed.info/sct",
-        "concept": [
-          {
-            "code": "404684003"
-          }
-        ]
       }
     ]
   }


### PR DESCRIPTION
SNOMED code: 404684003 was more of a catch all than previously understood - removed from the COPD ValueSet as the presence of that condition alone does not clearly define a COPD diagnosis.

Added a `declassify` API, to enable reprocessing from a clean, reset state.