### PR TITLE
remove SNOMED code: 404684003 ; declassify (#11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@ by looking for at least one `coding` from the following known COPD Condition cod
   - "code": "J44.0"
   - "code": "J44.1"
   - "code": "J44.9"
-- "system": "http://snomed.info/sct"
-  - "code": "404684003"
 
 ## How To Run
 As a flask application, `carl` exposes HTTP routes as well as a number of command line
@@ -55,12 +53,12 @@ portion of each command if deployed outside a docker container.
 
 To view available HTTP routes:
 ```
-sudo docker-compose exec carl flask routes
+docker-compose exec carl flask routes
 ```
 
 To view available CLI entry points:
 ```
-sudo docker-compose exec carl flask --help
+docker-compose exec carl flask --help
 ```
 
 Especially useful for debugging or testing, obtain any single Patient `_id` from the configured
@@ -71,11 +69,15 @@ curl -X PUT http://localhost:5000/classify/<Patient._id>/<site>
 
 To process the entire set of Patient resources found in the configured FHIR store:
 ```
-sudo docker-compose run carl flask classify
+docker-compose run carl flask classify
+```
+
+To reset, that is remove conditions added from previous runs:
+```
+docker-compose run carl flask declassify
 ```
 
 Complete example for site `uw`, captures both standard out and error to respective log files:
 ```
-sudo docker-compose run carl flask classify uw > /var/log/cnics_to_fhir/carl.out 2> /var/log/cnics_to_fhir/carl.err
+docker-compose run carl flask classify uw > /var/log/cnics_to_fhir/carl.out 2> /var/log/cnics_to_fhir/carl.err
 ```
-

--- a/carl/logic/copd.py
+++ b/carl/logic/copd.py
@@ -40,10 +40,10 @@ def patient_canonical_identifier(patient_id, site_code):
         return match[0]
 
 
-def patient_has(patient_id, value_set_uri):
-    """Determine if given patient has condition defined by given ValueSet
+def patient_has(patient_id, condition_codings):
+    """Determine if given patient has at least one condition in given codings
 
-    :returns: intersection of patient's condition codings and those in given ValueSet
+    :returns: intersection of patient's condition codings and those given
     """
     patient_codings = set()
     for bundle in next_resource_bundle(
@@ -53,8 +53,21 @@ def patient_has(patient_id, value_set_uri):
             for coding in entry['resource']['code']['coding']:
                 patient_codings.add(Coding(system=coding['system'], code=coding['code']))
 
-    condition_codings = valueset_codings(value_set_uri)
     return patient_codings.intersection(condition_codings)
+
+
+def delete_resource(resource):
+    """Delete given resource from FHIR_SERVER_URL
+
+    NB - this doesn't round-trip check if given resource already exists,
+    but rather does a DELETE with necessary search params to prevent duplicate
+    writes.  AKA conditional delete: https://www.hl7.org/fhir/http.html#cond-delete
+    """
+    url = f"{FHIR_SERVER_URL}{resource.search_url()}"
+    response = requests.delete(url=url, json=resource.as_fhir())
+    current_app.logger.debug(f"HAPI DELETE: {response.url}")
+    response.raise_for_status()
+    return response.json()
 
 
 def persist_resource(resource):
@@ -78,7 +91,9 @@ def process_4_COPD(patient_id, site_code):
     configured FHIR store for patients found to have a qualifying COPD Condition
     """
     current_app.logger.debug(f"process {patient_id} for COPD")
-    positive_codings = patient_has(patient_id=patient_id, value_set_uri=COPD_VALUESET_URI)
+    condition_codings = valueset_codings(COPD_VALUESET_URI)
+    positive_codings = patient_has(
+        patient_id=patient_id, condition_codings=condition_codings)
     results = {
         "patient_id": patient_canonical_identifier(patient_id, site_code) or patient_id,
         "COPD codings found": len(positive_codings) > 0}
@@ -89,8 +104,39 @@ def process_4_COPD(patient_id, site_code):
     condition.code = CodeableConcept(CNICS_COPD_coding)
     condition.subject = Patient(patient_id)
     response = persist_resource(resource=condition)
+    results['matched'] = True
     results['condition'] = response
     results['intersection'] = [coding.as_fhir() for coding in positive_codings]
+
+    current_app.logger.debug(results)
+    return results
+
+
+def remove_COPD_classification(patient_id, site_code):
+    """declassify given patient, i.e. remove added COPD Condition
+
+    Function used to reset or declassify patients previously found to have COPD,
+    this will remove the special Condition added during the classification step,
+    if found from the given patient.
+
+    NB: generates side-effects, namely a special Condition is removed from the
+    configured FHIR store for patients found to have previously gained said Condition
+    """
+    current_app.logger.debug(f"declassify {patient_id} of COPD")
+    classified_COPD_coding = set([CNICS_COPD_coding])
+    previously_classified = patient_has(
+        patient_id=patient_id, condition_codings=classified_COPD_coding)
+    results = {
+        "patient_id": patient_canonical_identifier(patient_id, site_code) or patient_id,
+        "COPD classification found": len(previously_classified) > 0}
+    if not previously_classified:
+        return results
+
+    condition = Condition()
+    condition.code = CodeableConcept(CNICS_COPD_coding)
+    condition.subject = Patient(patient_id)
+    delete_resource(resource=condition)
+    results['matched'] = True
 
     current_app.logger.debug(results)
     return results

--- a/carl/serialized/COPD_valueset.json
+++ b/carl/serialized/COPD_valueset.json
@@ -162,15 +162,6 @@
             "display": "J44.9"
           }
         ]
-      },
-      {
-        "system": "http://snomed.info/sct",
-        "concept": [
-          {
-            "code": "404684003",
-            "display": "404684003"
-          }
-        ]
       }
     ]
   }

--- a/carl/views.py
+++ b/carl/views.py
@@ -3,7 +3,7 @@ from flask import Blueprint, abort, current_app, jsonify
 from flask.json import JSONEncoder
 import timeit
 
-from carl.logic.copd import CNICS_IDENTIFIER_SYSTEM, process_4_COPD
+from carl.logic.copd import CNICS_IDENTIFIER_SYSTEM, process_4_COPD, remove_COPD_classification
 from carl.modules.paging import next_resource_bundle
 
 base_blueprint = Blueprint('base', __name__, cli_group=None)
@@ -63,11 +63,22 @@ def classify(patient_id, site_code):
 @click.argument('site')
 def classify_all(site):
     """Classify all patients found"""
+    return process_patients(process_4_COPD, site)
+
+
+@base_blueprint.cli.command("declassify")
+@click.argument('site')
+def declassify_all(site):
+    """Clear the (potentially) persisted COPD condition generated during classify"""
+    return process_patients(remove_COPD_classification, site)
+
+
+def process_patients(process_function, site):
     start = timeit.default_timer()
 
-    # Obtain batches of Patients with matching site identifier, process each in turn
+    # Obtain batches of Patients with site identifier, process each in turn
     processed_patients = 0
-    conditioned_patients = 0
+    matched_patients = 0
     patient_identifier_system = CNICS_IDENTIFIER_SYSTEM + site
     # To query on system portion only of an identifier, must include
     # trailing '|' used customarily to delimit `system|value`
@@ -76,14 +87,14 @@ def classify_all(site):
         assert bundle['resourceType'] == 'Bundle'
         for item in bundle.get('entry', []):
             assert item['resource']['resourceType'] == 'Patient'
-            results = process_4_COPD(item['resource']['id'], site)
+            results = process_function(patient_id=item['resource']['id'], site_code=site)
             processed_patients += 1
-            if 'condition' in results:
-                conditioned_patients += 1
+            if results.get('matched', False):
+                matched_patients += 1
 
     duration = timeit.default_timer() - start
     click.echo({
         'duration': f"{duration:.4f} seconds",
         'patient_identifier_system': patient_identifier_system,
         'processed_patients': processed_patients,
-        'conditioned_patients': conditioned_patients})
+        'matched_patients': matched_patients})

--- a/tests/test_modules/valueset.json
+++ b/tests/test_modules/valueset.json
@@ -133,14 +133,6 @@
             "code": "J44.9"
           }
         ]
-      },
-      {
-        "system": "http://snomed.info/sct",
-        "concept": [
-          {
-            "code": "404684003"
-          }
-        ]
       }
     ]
   }


### PR DESCRIPTION
* The catch-all SNOMED code 404684003 for conditions that didn't have an ICD9/10 code generated false positives on classification lookup.  It has been removed from the COPD value set.
Added a `declassify` API to clear previously generated conditions - to simplify resetting after a classification run.

* typo - Coding is an object not a dict!

* CNICS_COPD_coding is already a Coding object.

* check correct attribute to tally number of matching patients