### PR TITLE
Add timeout to all remote requests calls

### DIFF
--- a/carl/logic/copd.py
+++ b/carl/logic/copd.py
@@ -27,7 +27,7 @@ CNICS_IDENTIFIER_SYSTEM = "https://cnics.cirg.washington.edu/site-patient-id/"
 def patient_canonical_identifier(patient_id, site_code):
     """Return system|value identifier if patient has one for preferred system"""
     url = f"{FHIR_SERVER_URL}Patient/{patient_id}"
-    response = requests.get(url)
+    response = requests.get(url, timeout=30)
     if has_app_context():
         current_app.logger.debug(f"HAPI GET: {response.url}")
     response.raise_for_status()
@@ -68,7 +68,7 @@ def delete_resource(resource):
     writes.  AKA conditional delete: https://www.hl7.org/fhir/http.html#cond-delete
     """
     url = f"{FHIR_SERVER_URL}{resource.search_url()}"
-    response = requests.delete(url=url, json=resource.as_fhir())
+    response = requests.delete(url=url, json=resource.as_fhir(), timeout=30)
     current_app.logger.debug(f"HAPI DELETE: {response.url}")
     response.raise_for_status()
     return response.json()
@@ -82,7 +82,7 @@ def persist_resource(resource):
     writes.  AKA conditional update: https://www.hl7.org/fhir/http.html#cond-update
     """
     url = f"{FHIR_SERVER_URL}{resource.search_url()}"
-    response = requests.put(url=url, json=resource.as_fhir())
+    response = requests.put(url=url, json=resource.as_fhir(), timeout=30)
     current_app.logger.debug(f"HAPI PUT: {response.url}")
     response.raise_for_status()
     return response.json()

--- a/carl/logserverhandler.py
+++ b/carl/logserverhandler.py
@@ -24,7 +24,9 @@ class LogServerHandler(logging.Handler):
             "Authorization": f"Bearer {self.jwt}",
         }
         try:
-            response = requests.post(url=self.url, headers=headers, json=log_entry, timeout=30)
+            response = requests.post(
+                url=self.url, headers=headers, json=log_entry, timeout=30
+            )
             response.raise_for_status()
         except RequestException as ex:
             # bootstrap problems - attempt to log to root logger

--- a/carl/logserverhandler.py
+++ b/carl/logserverhandler.py
@@ -24,7 +24,7 @@ class LogServerHandler(logging.Handler):
             "Authorization": f"Bearer {self.jwt}",
         }
         try:
-            response = requests.post(url=self.url, headers=headers, json=log_entry)
+            response = requests.post(url=self.url, headers=headers, json=log_entry, timeout=30)
             response.raise_for_status()
         except RequestException as ex:
             # bootstrap problems - attempt to log to root logger

--- a/carl/modules/paging.py
+++ b/carl/modules/paging.py
@@ -24,7 +24,7 @@ def next_resource_bundle(resource_type, search_params=None):
     """
 
     url = f"{FHIR_SERVER_URL}{resource_type}"
-    response = requests.get(url=url, params=search_params)
+    response = requests.get(url=url, params=search_params, timeout=30)
     if has_app_context():
         current_app.logger.debug(f"HAPI GET: {response.url}")
     response.raise_for_status()
@@ -42,7 +42,7 @@ def next_resource_bundle(resource_type, search_params=None):
         if not next_page_link:
             return
 
-        response = requests.get(next_page_link)
+        response = requests.get(next_page_link, timeout=30)
         current_app.logger.debug(f"HAPI GET: {response.url}")
         response.raise_for_status()
         bundle = response.json()

--- a/carl/modules/resource.py
+++ b/carl/modules/resource.py
@@ -27,7 +27,7 @@ class Resource(object):
         if FHIR_SERVER_URL:
             headers = {"Cache-Control": "no-cache"}
             response = requests.get(
-                "/".join((FHIR_SERVER_URL, self.search_url())), headers=headers
+                "/".join((FHIR_SERVER_URL, self.search_url())), headers=headers, timeout=30
             )
             response.raise_for_status()
 

--- a/carl/modules/resource.py
+++ b/carl/modules/resource.py
@@ -27,7 +27,9 @@ class Resource(object):
         if FHIR_SERVER_URL:
             headers = {"Cache-Control": "no-cache"}
             response = requests.get(
-                "/".join((FHIR_SERVER_URL, self.search_url())), headers=headers, timeout=30
+                "/".join((FHIR_SERVER_URL, self.search_url())),
+                headers=headers,
+                timeout=30,
             )
             response.raise_for_status()
 

--- a/carl/modules/valueset.py
+++ b/carl/modules/valueset.py
@@ -30,7 +30,7 @@ def valueset_codings(url):
     """Obtain set of codings in matching ValueSet by url field"""
     search_params = {"url": url}
     resource_path = f"{FHIR_SERVER_URL}ValueSet"
-    response = requests.get(resource_path, params=search_params)
+    response = requests.get(resource_path, params=search_params, timeout=30)
     response.raise_for_status()
     bundle = response.json()
     if bundle["total"] != 1:

--- a/carl/serialized/upload.py
+++ b/carl/serialized/upload.py
@@ -35,7 +35,7 @@ def load_files():
                 endpoint += resource.search_url()
 
             current_app.logger.info(f"PUT {fname.name} to {endpoint}")
-            response = requests.put(endpoint, json=data)
+            response = requests.put(endpoint, json=data, timeout=30)
             current_app.logger.info(
                 f"status {response.status_code}, text {response.text}"
             )


### PR DESCRIPTION
Address lack of timeout in all remote `requests` calls, as flagged by Semgrep reports.

Semgrep report at: https://docs.google.com/document/d/1UwoofOLLofnV3r9rC11uYb91GE4y6r2WtHAAfuuAxzE/edit 