### PR TITLE
Classify for COPD MedicationRequests

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,41 @@ embodies a `condition classifier`; a logic engine capable of acting on trigger e
 an external FHIR store for state and generating conditions when appropriate, pushed back into
 the same external FHIR store.
 
-## Conditions
-Start simple, in prototype style, with the intent to replace logic engine and related components
-as the need arises.
+## Marker Conditions
+### "COPD" & "COPD, exacerbation" Condition
 
-### 'COPD' & 'COPD, exacerbation'
-Determine if a Patient should receive a COPD Condition with the `cnics` namespace system
-by looking for at least one `coding` from the following known COPD Condition codings:
+Patients found to have at least one condition from the CNICS COPD Value Set,
+are marked with a [Condition](https://www.hl7.org/fhir/condition.html) with `code`:
 
+```
+{
+    system="https://cpro.cirg.washington.edu/groups",
+    code="CNICS.COPD2021.11.001",
+    display="COPD PRO group member",
+}
+```
+
+Example FHIR Query to obtain [FHIR Patients](https://www.hl7.org/fhir/patient.html) having said condition:
+```
+https://SERVER/fhir/Patient?_has:Condition:patient:code=CNICS.COPD2021.11.001
+```
+### COPD MedicationRequest
+
+Patients found to have at least one [MedicationRequest](https://www.hl7.org/fhir/medicationrequest.html)
+from the CNICS COPD Medication Value Set, are marked with a
+[Condition](https://www.hl7.org/fhir/condition.html) with `code`:
+
+```
+{
+    system="https://cpro.cirg.washington.edu/groups",
+    code="CNICS.COPDMED2022.03.001",
+    display="COPD Medication group member",
+}
+```
+
+## ValueSets
+### CNICS COPD Value Set
+List of qualifying COPD and COPD exacerbation condition codings.
 - "system": "http://hl7.org/fhir/sid/icd-9-cm"
   - "code": "491"
   - "code": "491.0"
@@ -43,6 +70,30 @@ by looking for at least one `coding` from the following known COPD Condition cod
   - "code": "J44.0"
   - "code": "J44.1"
   - "code": "J44.9"
+
+### CNICS COPD Medication Value Set
+List of qualifying COPD MedicationRequest codings.
+- "system": "https://cnics.cirg.washington.edu/medication-name"
+  - "code": "IPRATROPIUM-INHALED"
+  - "code": "ARFORMOTEROL"
+  - "code": "FORMOTEROL"
+  - "code": "OLODATEROL"
+  - "code": "SALMETEROL"
+  - "code": "ACLIDINIUM"
+  - "code": "TIOTROPIUM"
+  - "code": "UMECLIDINIUM"
+  - "code": "FLUTICASONE FUROATE + UMECLIDINIUM + VILANTEROL"
+  - "code": "ALBUTEROL + IPRATROPIUM"
+  - "code": "IPRATROPIUM +  FENOTEROL"
+  - "code": "ACLIDINIUM + FORMOTEROL"
+  - "code": "BUDESONIDE + FORMOTEROL"
+  - "code": "FLUTICASONE + SALMETEROL"
+  - "code": "FLUTICASONE + VILANTEROL"
+  - "code": "MOMETASONE + FORMOTEROL"
+  - "code": "OLODATEROL + TIOTROPIUM"
+  - "code": "UMECLIDINIUM +  VILANTEROL"
+  - "code": "GLYCOPYRROLATE + FORMOTEROL FUMARATE"
+
 
 ## How To Run
 As a flask application, `carl` exposes HTTP routes as well as a number of command line

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ an external FHIR store for state and generating conditions when appropriate, pus
 the same external FHIR store.
 
 ## Marker Conditions
-### "COPD" & "COPD, exacerbation" Condition
+### "COPD" or "COPD, exacerbation" Condition
 
 Patients found to have at least one condition from the CNICS COPD Value Set,
 are marked with a [Condition](https://www.hl7.org/fhir/condition.html) with `code`:
@@ -32,7 +32,7 @@ from the CNICS COPD Medication Value Set, are marked with a
 {
     system="https://cpro.cirg.washington.edu/groups",
     code="CNICS.COPDMED2022.03.001",
-    display="COPD Medication group member",
+    display="COPD with Medication PRO group member",
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ the same external FHIR store.
 ### "COPD" or "COPD, exacerbation" Condition
 
 Patients found to have at least one condition from the CNICS COPD Value Set,
-are marked with a [Condition](https://www.hl7.org/fhir/condition.html) with `code`:
+are marked with [Condition](https://www.hl7.org/fhir/condition.html) having `code`:
 
 ```
 {
@@ -22,18 +22,23 @@ Example FHIR Query to obtain [FHIR Patients](https://www.hl7.org/fhir/patient.ht
 ```
 https://SERVER/fhir/Patient?_has:Condition:patient:code=CNICS.COPD2021.11.001
 ```
-### COPD MedicationRequest
+### COPD With MedicationRequest
 
-Patients found to have at least one [MedicationRequest](https://www.hl7.org/fhir/medicationrequest.html)
-from the CNICS COPD Medication Value Set, are marked with a
-[Condition](https://www.hl7.org/fhir/condition.html) with `code`:
+Patients qualifying for the `COPD PRO group marker` also found to have at least one
+[MedicationRequest](https://www.hl7.org/fhir/medicationrequest.html) from the CNICS COPD Medication Value
+Set, are marked with [Condition](https://www.hl7.org/fhir/condition.html) having `code`:
 
 ```
 {
     system="https://cpro.cirg.washington.edu/groups",
     code="CNICS.COPDMED2022.03.001",
-    display="COPD with Medication PRO group member",
+    display="COPD PRO group member with qualifying MedicationRequest",
 }
+```
+
+Example FHIR Query to obtain [FHIR Patients](https://www.hl7.org/fhir/patient.html) having said condition:
+```
+https://SERVER/fhir/Patient?_has:Condition:patient:code=CNICS.COPDMED2022.03.001
 ```
 
 ## ValueSets

--- a/carl/logic/copd.py
+++ b/carl/logic/copd.py
@@ -28,7 +28,7 @@ CNICS_COPD_coding = Coding(
     display="COPD PRO group member",
 )
 
-# Designated coding used to tag users found to be COPD PRO group members with qualifying MedicationRequest
+# Designated coding used to tag COPD PRO group members with qualifying MedicationRequest
 CNICS_COPD_medication_coding = Coding(
     system="https://cpro.cirg.washington.edu/groups",
     code="CNICS.COPDMED2022.03.001",

--- a/carl/logic/copd.py
+++ b/carl/logic/copd.py
@@ -66,6 +66,10 @@ def patient_has(patient_id, resource_type, resource_codings):
         resource_type=resource_type, search_params={"subject": patient_id}
     ):
         for entry in bundle.get("entry", []):
+            try:
+                x = entry["resource"]["code"]["coding"]
+            except KeyError:
+                raise ValueError(f"no resource in {entry}")
             for coding in entry["resource"]["code"]["coding"]:
                 patient_codings.add(
                     Coding(system=coding["system"], code=coding["code"])

--- a/carl/logic/copd.py
+++ b/carl/logic/copd.py
@@ -10,15 +10,27 @@ from carl.modules.paging import next_resource_bundle
 from carl.modules.patient import Patient
 from carl.modules.valueset import valueset_codings
 
-# ValueSet for all known COPD condition codings - should match "url" in:
+# ValueSet for all known COPD Condition codings - should match "url" in:
 # ``carl.serialized.COPD_valueset.json``
 COPD_VALUESET_URI = "http://cnics-cirg.washington.edu/fhir/ValueSet/CNICS-COPD-codings"
+
+# ValueSet for all known COPD MedicationRequest codings - should match "url" in:
+# ``carl.serialized.COPD_medication_valueset.json``
+COPD_MEDICATION_VALUESET_URI = "http://cnics-cirg.washington.edu/fhir/ValueSet/CNICS-COPD-medication-codings"
+
 
 # Designated coding used to tag users eligible for COPD questionnaire
 CNICS_COPD_coding = Coding(
     system="https://cpro.cirg.washington.edu/groups",
     code="CNICS.COPD2021.11.001",
     display="COPD PRO group member",
+)
+
+# Designated coding used to tag users found to have COPD medications
+CNICS_COPD_medication_coding = Coding(
+    system="https://cpro.cirg.washington.edu/groups",
+    code="CNICS.COPDMED2022.03.001",
+    display="COPD Medication group member",
 )
 
 CNICS_IDENTIFIER_SYSTEM = "https://cnics.cirg.washington.edu/site-patient-id/"
@@ -42,14 +54,14 @@ def patient_canonical_identifier(patient_id, site_code):
         return match[0]
 
 
-def patient_has(patient_id, condition_codings):
-    """Determine if given patient has at least one condition in given codings
+def patient_has(patient_id, resource_type, resource_codings):
+    """Determine if given patient has at least one matching resource in given codings
 
-    :returns: intersection of patient's condition codings and those given
+    :returns: intersection of patient's resource with the given codings
     """
     patient_codings = set()
     for bundle in next_resource_bundle(
-        resource_type="Condition", search_params={"subject": patient_id}
+        resource_type=resource_type, search_params={"subject": patient_id}
     ):
         for entry in bundle.get("entry", []):
             for coding in entry["resource"]["code"]["coding"]:
@@ -57,7 +69,7 @@ def patient_has(patient_id, condition_codings):
                     Coding(system=coding["system"], code=coding["code"])
                 )
 
-    return patient_codings.intersection(condition_codings)
+    return patient_codings.intersection(resource_codings)
 
 
 def delete_resource(resource):
@@ -88,20 +100,24 @@ def persist_resource(resource):
     return response.json()
 
 
-def process_4_COPD(patient_id, site_code):
+def process_4_COPD_conditions(patient_id, site_code):
     """Process given patient for COPD
 
-    NB: generates side-effects, namely a special Condition is persisted in the
+    NB: generates side effects, namely a special Condition is persisted in the
     configured FHIR store for patients found to have a qualifying COPD Condition
     """
-    current_app.logger.debug(f"process {patient_id} for COPD")
+    current_app.logger.debug(f"process {patient_id} for COPD Conditions")
+
+    # process for matching conditions in value set
     condition_codings = valueset_codings(COPD_VALUESET_URI)
     positive_codings = patient_has(
-        patient_id=patient_id, condition_codings=condition_codings
+        patient_id=patient_id,
+        resource_type="Condition",
+        resource_codings=condition_codings
     )
     results = {
         "patient_id": patient_canonical_identifier(patient_id, site_code) or patient_id,
-        "COPD codings found": len(positive_codings) > 0,
+        "COPD Condition codings found": len(positive_codings) > 0,
     }
     if not positive_codings:
         return results
@@ -118,20 +134,54 @@ def process_4_COPD(patient_id, site_code):
     return results
 
 
+def process_4_COPD_medications(patient_id, site_code):
+    """Process given patient for COPD medications
+
+    NB: generates side effects, namely a special Condition is persisted in the
+    configured FHIR store for patients found to have a qualifying COPD MedicationRequest
+    """
+    current_app.logger.debug(f"process {patient_id} for COPD Medications")
+
+    # process for mediation requests in value set
+    medication_codings = valueset_codings(COPD_MEDICATION_VALUESET_URI)
+    positive_codings = patient_has(
+        patient_id=patient_id,
+        resource_type="MedicationRequest",
+        resource_codings=medication_codings
+    )
+    results = {
+        "patient_id": patient_canonical_identifier(patient_id, site_code) or patient_id,
+        "COPD MedicationRequest codings found": len(positive_codings) > 0,
+    }
+    if not positive_codings:
+        return results
+
+    condition = Condition()
+    condition.code = CodeableConcept(CNICS_COPD_medication_coding)
+    condition.subject = Patient(patient_id)
+    response = persist_resource(resource=condition)
+    results["matched"] = True
+    results["condition"] = response
+    results["intersection"] = [coding.as_fhir() for coding in positive_codings]
+
+    current_app.logger.debug(results)
+    return results
+
+
 def remove_COPD_classification(patient_id, site_code):
-    """declassify given patient, i.e. remove added COPD Condition
+    """declassify given patient, i.e. remove added COPD Conditions
 
     Function used to reset or declassify patients previously found to have COPD,
     this will remove the special Condition added during the classification step,
     if found from the given patient.
 
-    NB: generates side-effects, namely a special Condition is removed from the
-    configured FHIR store for patients found to have previously gained said Condition
+    NB: generates side effects, namely special Conditions are removed from the
+    configured FHIR store for patients found to have previously gained said Conditions
     """
     current_app.logger.debug(f"declassify {patient_id} of COPD")
-    classified_COPD_coding = set([CNICS_COPD_coding])
+    classified_COPD_codings = set([CNICS_COPD_coding, CNICS_COPD_medication_coding])
     previously_classified = patient_has(
-        patient_id=patient_id, condition_codings=classified_COPD_coding
+        patient_id=patient_id, condition_codings=classified_COPD_codings
     )
     results = {
         "patient_id": patient_canonical_identifier(patient_id, site_code) or patient_id,
@@ -140,10 +190,13 @@ def remove_COPD_classification(patient_id, site_code):
     if not previously_classified:
         return results
 
-    condition = Condition()
-    condition.code = CodeableConcept(CNICS_COPD_coding)
-    condition.subject = Patient(patient_id)
-    delete_resource(resource=condition)
+    # Blindly try to remove all, knowing only one may be present on a patient
+    for coding in classified_COPD_codings:
+        condition = Condition()
+        condition.code = CodeableConcept(coding)
+        condition.subject = Patient(patient_id)
+        delete_resource(resource=condition)
+
     results["matched"] = True
 
     current_app.logger.debug(results)

--- a/carl/logic/copd.py
+++ b/carl/logic/copd.py
@@ -16,7 +16,9 @@ COPD_VALUESET_URI = "http://cnics-cirg.washington.edu/fhir/ValueSet/CNICS-COPD-c
 
 # ValueSet for all known COPD MedicationRequest codings - should match "url" in:
 # ``carl.serialized.COPD_medication_valueset.json``
-COPD_MEDICATION_VALUESET_URI = "http://cnics-cirg.washington.edu/fhir/ValueSet/CNICS-COPD-medication-codings"
+COPD_MEDICATION_VALUESET_URI = (
+    "http://cnics-cirg.washington.edu/fhir/ValueSet/CNICS-COPD-medication-codings"
+)
 
 
 # Designated coding used to tag users eligible for COPD questionnaire
@@ -113,7 +115,7 @@ def process_4_COPD_conditions(patient_id, site_code):
     positive_codings = patient_has(
         patient_id=patient_id,
         resource_type="Condition",
-        resource_codings=condition_codings
+        resource_codings=condition_codings,
     )
     results = {
         "patient_id": patient_canonical_identifier(patient_id, site_code) or patient_id,
@@ -147,7 +149,7 @@ def process_4_COPD_medications(patient_id, site_code):
     positive_codings = patient_has(
         patient_id=patient_id,
         resource_type="MedicationRequest",
-        resource_codings=medication_codings
+        resource_codings=medication_codings,
     )
     results = {
         "patient_id": patient_canonical_identifier(patient_id, site_code) or patient_id,

--- a/carl/logic/copd.py
+++ b/carl/logic/copd.py
@@ -28,11 +28,11 @@ CNICS_COPD_coding = Coding(
     display="COPD PRO group member",
 )
 
-# Designated coding used to tag users found to have COPD medications
+# Designated coding used to tag users found to be COPD PRO group members with qualifying MedicationRequest
 CNICS_COPD_medication_coding = Coding(
     system="https://cpro.cirg.washington.edu/groups",
     code="CNICS.COPDMED2022.03.001",
-    display="COPD Medication group member",
+    display="COPD PRO group member with qualifying MedicationRequest",
 )
 
 CNICS_IDENTIFIER_SYSTEM = "https://cnics.cirg.washington.edu/site-patient-id/"

--- a/carl/logic/copd.py
+++ b/carl/logic/copd.py
@@ -154,7 +154,7 @@ def process_4_COPD_medications(patient_id, site_code):
         patient_id=patient_id,
         resource_type="MedicationRequest",
         resource_codings=medication_codings,
-        code_attribute="medicationCodeableConcept"
+        code_attribute="medicationCodeableConcept",
     )
     results = {
         "patient_id": patient_canonical_identifier(patient_id, site_code) or patient_id,
@@ -190,7 +190,7 @@ def remove_COPD_classification(patient_id, site_code):
     previously_classified = patient_has(
         patient_id=patient_id,
         resource_codings=classified_COPD_codings,
-        resource_type="Condition"
+        resource_type="Condition",
     )
     results = {
         "patient_id": patient_canonical_identifier(patient_id, site_code) or patient_id,

--- a/carl/modules/paging.py
+++ b/carl/modules/paging.py
@@ -7,7 +7,7 @@ from carl.config import FHIR_SERVER_URL
 
 
 def next_page_link_from_bundle(bundle):
-    next_page_link = jmespath.search("link[?relation==`next`].[url]", bundle)
+    next_page_link = jmespath.search("link[?relation=='next'].[url]", bundle)
     if not (next_page_link and len(next_page_link)):
         return
 

--- a/carl/modules/valueset.py
+++ b/carl/modules/valueset.py
@@ -26,6 +26,7 @@ class ValueSet(Resource):
         return cls(url=data["url"])
 
 
+# TODO: cache this never changing round-trip
 def valueset_codings(url):
     """Obtain set of codings in matching ValueSet by url field"""
     search_params = {"url": url}

--- a/carl/serialized/COPD_medication_valueset.json
+++ b/carl/serialized/COPD_medication_valueset.json
@@ -1,0 +1,123 @@
+{
+  "resourceType": "ValueSet",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/StructureDefinition/shareablevalueset"
+    ]
+  },
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n\t\t\t<p>Value set &quot;CNICS Medication Codes for COPD&quot;</p>\n\t\t\t<p>Developed by: CIRG</p>\n\t\t</div>"
+  },
+  "url": "http://cnics-cirg.washington.edu/fhir/ValueSet/CNICS-COPD-medication-codings",
+  "identifier": [
+    {
+      "system": "http://cnics-cirg.washington.edu/fhir/identifier/valueset",
+      "value": "CNICS-COPD-medication-codings"
+    }
+  ],
+  "version": "20220202",
+  "name": "CNICS COPD Medication Codings",
+  "status": "draft",
+  "experimental": true,
+  "date": "2022-02-02",
+  "publisher": "CIRG",
+  "contact": [
+    {
+      "name": "CIRG project team",
+      "telecom": [
+        {
+          "system": "url",
+          "value": "https://www.cirg.washington.edu/"
+        }
+      ]
+    }
+  ],
+  "description": "ValueSet including all the medication codings used by CNICS requested for COPD or COPD, exacerbation",
+  "compose": {
+    "lockedDate": "2022-04-06",
+    "include": [
+      {
+        "system": "https://cnics.cirg.washington.edu/medication-name",
+        "concept": [
+          {
+            "code": "IPRATROPIUM-INHALED",
+            "display": "IPRATROPIUM-INHALED"
+          },
+          {
+            "code": "ARFORMOTEROL",
+            "display": "ARFORMOTEROL"
+          },
+          {
+            "code": "FORMOTEROL",
+            "display": "FORMOTEROL"
+          },
+          {
+            "code": "OLODATEROL",
+            "display": "OLODATEROL"
+          },
+          {
+            "code": "SALMETEROL",
+            "display": "SALMETEROL"
+          },
+          {
+            "code": "ACLIDINIUM",
+            "display": "ACLIDINIUM"
+          },
+          {
+            "code": "TIOTROPIUM",
+            "display": "TIOTROPIUM"
+          },
+          {
+            "code": "UMECLIDINIUM",
+            "display": "UMECLIDINIUM"
+          },
+          {
+            "code": "FLUTICASONE FUROATE + UMECLIDINIUM + VILANTEROL",
+            "display": "FLUTICASONE FUROATE + UMECLIDINIUM + VILANTEROL"
+          },
+          {
+            "code": "ALBUTEROL + IPRATROPIUM",
+            "display": "ALBUTEROL + IPRATROPIUM"
+          },
+          {
+            "code": "IPRATROPIUM +  FENOTEROL",
+            "display": "IPRATROPIUM +  FENOTEROL"
+          },
+          {
+            "code": "ACLIDINIUM + FORMOTEROL",
+            "display": "ACLIDINIUM + FORMOTEROL"
+          },
+          {
+            "code": "BUDESONIDE + FORMOTEROL",
+            "display": "BUDESONIDE + FORMOTEROL"
+          },
+          {
+            "code": "FLUTICASONE + SALMETEROL",
+            "display": "FLUTICASONE + SALMETEROL"
+          },
+          {
+            "code": "FLUTICASONE + VILANTEROL",
+            "display": "FLUTICASONE + VILANTEROL"
+          },
+          {
+            "code": "MOMETASONE + FORMOTEROL",
+            "display": "MOMETASONE + FORMOTEROL"
+          },
+          {
+            "code": "OLODATEROL + TIOTROPIUM",
+            "display": "OLODATEROL + TIOTROPIUM"
+          },
+          {
+            "code": "UMECLIDINIUM +  VILANTEROL",
+            "display": "UMECLIDINIUM +  VILANTEROL"
+          },
+          {
+            "code": "GLYCOPYRROLATE + FORMOTEROL FUMARATE",
+            "display": "GLYCOPYRROLATE + FORMOTEROL FUMARATE"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/carl/views.py
+++ b/carl/views.py
@@ -78,7 +78,7 @@ def classify_all(site):
     return process_patients(
         process_functions=(process_4_COPD_conditions, process_4_COPD_medications),
         site=site,
-        require_all=True
+        require_all=True,
     )
 
 

--- a/carl/views.py
+++ b/carl/views.py
@@ -86,7 +86,7 @@ def classify_all(site):
 @click.argument("site")
 def declassify_all(site):
     """Clear the (potentially) persisted COPD condition generated during classify"""
-    return process_patients(remove_COPD_classification, site)
+    return process_patients((remove_COPD_classification,), site)
 
 
 def process_patients(process_functions, site, require_all=False):

--- a/carl/views.py
+++ b/carl/views.py
@@ -73,7 +73,9 @@ def classify(patient_id, site_code):
 @click.argument("site")
 def classify_all(site):
     """Classify all patients found"""
-    return process_patients((process_4_COPD_conditions, process_4_COPD_medications), site)
+    return process_patients(
+        (process_4_COPD_conditions, process_4_COPD_medications), site
+    )
 
 
 @base_blueprint.cli.command("declassify")

--- a/carl/views.py
+++ b/carl/views.py
@@ -73,7 +73,7 @@ def classify(patient_id, site_code):
 @click.argument("site")
 def classify_all(site):
     """Classify all patients found"""
-    return process_patients(process_4_COPD_conditions, site)
+    return process_patients((process_4_COPD_conditions, process_4_COPD_medications), site)
 
 
 @base_blueprint.cli.command("declassify")


### PR DESCRIPTION
Fix for #14, classification now includes an additional step, functions much like the one to classify on Conditions; look at a patient's MedicationRequest codings, if any are in the respective value set, the patient picks up an additional Condition marking this classification:

```
{
    system="https://cpro.cirg.washington.edu/groups",
    code="CNICS.COPDMED2022.03.001",
    display="COPD Medication group member",
}
``` 