### PR TITLE
Re-add the CNICS-coded COPD conditions into the COPD valueset.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ List of qualifying COPD and COPD exacerbation condition codings.
   - "code": "J44.0"
   - "code": "J44.1"
   - "code": "J44.9"
+- "system": "https://cnics.cirg.washington.edu/diagnosis-name"
+  - "code": "COPD"
+  - "code": "COPD, exacerbation"
 
 ### CNICS COPD Medication Value Set
 List of qualifying COPD MedicationRequest codings.

--- a/carl/serialized/COPD_valueset.json
+++ b/carl/serialized/COPD_valueset.json
@@ -16,11 +16,11 @@
       "value": "CNICS-COPD-codings"
     }
   ],
-  "version": "20211021",
+  "version": "20220428",
   "name": "CNICS COPD Codings",
   "status": "draft",
   "experimental": true,
-  "date": "2021-10-21",
+  "date": "2022-04-28",
   "publisher": "CIRG",
   "contact": [
     {
@@ -35,7 +35,7 @@
   ],
   "description": "ValueSet including all the codings used by CNICS to define COPD or COPD, exacerbation",
   "compose": {
-    "lockedDate": "2021-10-21",
+    "lockedDate": "2022-04-28",
     "include": [
       {
         "system": "http://hl7.org/fhir/sid/icd-9-cm",
@@ -160,6 +160,19 @@
           {
             "code": "J44.9",
             "display": "J44.9"
+          }
+        ]
+      },
+      {
+        "system": "https://cnics.cirg.washington.edu/diagnosis-name",
+        "concept": [
+          {
+            "code": "COPD",
+            "display": "COPD"
+          },
+          {
+            "code": "COPD, exacerbation",
+            "display": "COPD, exacerbation"
           }
         ]
       }

--- a/tests/test_modules/valueset.json
+++ b/tests/test_modules/valueset.json
@@ -16,11 +16,11 @@
       "value": "CNICS-COPD-codings"
     }
   ],
-  "version": "20211021",
+  "version": "20220428",
   "name": "CNICS COPD Codings",
   "status": "draft",
   "experimental": true,
-  "date": "2021-10-21",
+  "date": "2022-04-28",
   "publisher": "CIRG",
   "contact": [
     {
@@ -35,7 +35,7 @@
   ],
   "description": "ValueSet including all the codings used by CNICS to define COPD or COPD, exacerbation",
   "compose": {
-    "lockedDate": "2021-10-21",
+    "lockedDate": "2022-04-28",
     "include": [
       {
         "system": "http://hl7.org/fhir/sid/icd-9-cm",
@@ -131,6 +131,17 @@
           },
           {
             "code": "J44.9"
+          }
+        ]
+      },
+      {
+        "system": "https://cnics.cirg.washington.edu/diagnosis-name",
+        "concept": [
+          {
+            "code": "COPD"
+          },
+          {
+            "code": "COPD, exacerbation"
           }
         ]
       }


### PR DESCRIPTION
@pbugni Please review this PR to re-add the CNICS-coded values for "COPD" and "COPD, exacerbation" to the valueset carl uses to determine matching COPD conditions.

I wasn't sure if this files also needs to be updated or not: '/tests/test_modules/valueset_bundle.json'

Also not sure if I needed to add another JSON file to 'carl/serialized' like the ones in there for ICD-9 ('ICD-9_codesystem.json') and ICD-10 ('ICD-10_codesystem.json').  It appears that those aren't being used anywhere, but I could be mistaken.

Please let me know if you see anything that needs fixing here, thanks!